### PR TITLE
Add shutup symbol for end of file pointer.

### DIFF
--- a/src/app/code/community/Fontis/FeedsGenerator/Model/child_run.php
+++ b/src/app/code/community/Fontis/FeedsGenerator/Model/child_run.php
@@ -18,8 +18,8 @@
 
 $input = '';
 do {
-    $input .= fgets(STDIN);
-} while (!feof(STDIN));
+    $input .= @fgets(STDIN);
+} while (!@feof(STDIN));
 
 $config = json_decode($input);
 


### PR DESCRIPTION
When there is no input at all, a PHP warning is generated. It is not uncommon to see huge log files as a result.
